### PR TITLE
Update HapVideoDRAFT.md

### DIFF
--- a/documentation/HapVideoDRAFT.md
+++ b/documentation/HapVideoDRAFT.md
@@ -48,6 +48,8 @@ The fourth byte of the header is an unsigned integer denoting the S3 and second-
 |0xBE                   |RGBA DXT5         |Snappy                  |
 |0xAF                   |Scaled YCoCg DXT5 |None                    |
 |0xBF                   |Scaled YCoCg DXT5 |Snappy                  |
+|0xAC                   |RGBA BC7          |None                    |
+|0xBC                   |RGBA BC7          |Snappy                  |
 
 Frame Data
 ----------


### PR DESCRIPTION
My users don't find Hap Alpha too useful due to the quality issues of the RGB channels inherent in DXT5 compression. I'd like to reserve this code for BC7 RGBA images so I can add support in the near future. Encoders are still quite slow (6 secs using CUDA on a K5000 for a 1920x1080 image), but getting to the point where it's usable when needed. I think we'd call this Hap Q Alpha maybe?