### PR TITLE
Return error if frame is chunked and no valid callback was given.

### DIFF
--- a/source/hap.c
+++ b/source/hap.c
@@ -418,6 +418,11 @@ unsigned int HapDecode(const void *inputBuffer, unsigned long inputBufferBytes,
     compressor = hap_top_4_bits(sectionType);
     textureFormat = hap_bottom_4_bits(sectionType);
 
+    if (compressor == kHapCompressorComplex && callback == NULL)
+    {
+        return HapResult_Bad_Arguments;
+    }
+
     /*
      Pass the texture format out
      */


### PR DESCRIPTION
Otherwise it's possible for an invalid HapDecodeCallback to be called. Then bad things happen.
